### PR TITLE
Collections header test 2

### DIFF
--- a/src/Apps/Collect/Components/Collection/Header/__tests__/Header.test.tsx
+++ b/src/Apps/Collect/Components/Collection/Header/__tests__/Header.test.tsx
@@ -1,99 +1,207 @@
 import { EntityHeader } from "@artsy/palette"
-import { shallow } from "enzyme"
+import { MockBoot } from "DevTools/MockBoot"
+import { mount, shallow } from "enzyme"
 import React from "react"
-import { getFeaturedArtists } from "../index"
+import { CollectionHeader, getFeaturedArtists, Props } from "../index"
 
-describe("getFeaturedArtists", () => {
-  const mockMediator = jest.fn()
-
-  const collection = {
-    title: "KAWS: Toys",
-    query: {
-      gene_id: null,
-      artist_id: null,
-      artist_ids: ["4e934002e340fa0001005336"],
-    },
-    artworks: {
-      merchandisable_artists: [
-        {
-          id: "kaws",
-          _id: "4e934002e340fa0001005336",
-          name: "KAWS",
-          imageUrl:
-            "https://d32dm0rphc51dk.cloudfront.net/WhacjFyMKlMkNVzncPjlRA/square.jpg",
-          birthday: "1974",
-          nationality: "American",
+describe("collections header", () => {
+  let props: Props
+  beforeEach(() => {
+    props = {
+      artworks: {
+        " $refType": null,
+        merchandisable_artists: [
+          {
+            id: "kaws",
+            _id: "4e934002e340fa0001005336",
+            name: "KAWS",
+            imageUrl:
+              "https://d32dm0rphc51dk.cloudfront.net/WhacjFyMKlMkNVzncPjlRA/square.jpg",
+            birthday: "1974",
+            nationality: "American",
+            " $fragmentRefs": null,
+          },
+          {
+            id: "robert-lazzarini",
+            _id: "4f5f64c23b555230ac0003ae",
+            name: "Robert Lazzarini",
+            imageUrl:
+              "https://d32dm0rphc51dk.cloudfront.net/1npk1i_Xua5q8Hv0YOq_3g/square.jpg",
+            birthday: "1965",
+            nationality: "American",
+            " $fragmentRefs": null,
+          },
+          {
+            id: "medicom",
+            _id: "58fe85ee275b2450a0fd2b51",
+            name: "Medicom",
+            imageUrl:
+              "https://d32dm0rphc51dk.cloudfront.net/jUMOidRmCQ0RyynXM_sFzQ/square.jpg",
+            birthday: "",
+            nationality: "",
+            " $fragmentRefs": null,
+          },
+          {
+            id: "medicom-toy-slash-china",
+            _id: "5b9821af86c8aa21d364dde5",
+            name: "Medicom Toy/China",
+            imageUrl:
+              "https://d32dm0rphc51dk.cloudfront.net/npEmyaOeaPzkfEHX5VsmQg/square.jpg",
+            birthday: "",
+            nationality: "",
+            " $fragmentRefs": null,
+          },
+        ],
+      },
+      collection: {
+        title: "KAWS: Toys",
+        category: "Collectible Sculptures",
+        slug: "kaws-toys",
+        headerImage:
+          "https://d32dm0rphc51dk.cloudfront.net/WhacjFyMKlMkNVzncPjlRA/square.jpg",
+        query: {
+          gene_id: null,
+          artist_id: null,
+          artist_ids: ["4e934002e340fa0001005336"],
         },
-        {
-          id: "robert-lazzarini",
-          _id: "4f5f64c23b555230ac0003ae",
-          name: "Robert Lazzarini",
-          imageUrl:
-            "https://d32dm0rphc51dk.cloudfront.net/1npk1i_Xua5q8Hv0YOq_3g/square.jpg",
-          birthday: "1965",
-          nationality: "American",
-        },
-        {
-          id: "medicom",
-          _id: "58fe85ee275b2450a0fd2b51",
-          name: "Medicom",
-          imageUrl:
-            "https://d32dm0rphc51dk.cloudfront.net/jUMOidRmCQ0RyynXM_sFzQ/square.jpg",
-          birthday: "",
-          nationality: "",
-        },
-        {
-          id: "medicom-toy-slash-china",
-          _id: "5b9821af86c8aa21d364dde5",
-          name: "Medicom Toy/China",
-          imageUrl:
-            "https://d32dm0rphc51dk.cloudfront.net/npEmyaOeaPzkfEHX5VsmQg/square.jpg",
-          birthday: "",
-          nationality: "",
-        },
-      ],
-    },
-  }
-
-  it("returns the queried artists when there is explicit artist_ids", () => {
-    const results = getFeaturedArtists(
-      9,
-      collection,
-      true,
-      collection.artworks.merchandisable_artists,
-      mockMediator,
-      {}
-    )
-
-    expect(results.length).toEqual(1)
+      },
+    }
   })
 
-  it("passes correct arguments featuredArtistsEntityCollection", () => {
-    const wrapper = shallow(
-      <div>
-        {getFeaturedArtists(
-          9,
-          collection,
-          true,
-          collection.artworks.merchandisable_artists,
-          mockMediator,
-          {}
-        )}
-      </div>
-    )
+  describe("getFeaturedArtists", () => {
+    const mockMediator = jest.fn()
 
-    const entities = wrapper.find(EntityHeader)
-    expect(entities.length).toBe(1)
+    it("returns the queried artists when there is explicit artist_ids", () => {
+      const { collection, artworks } = props
+      const results = getFeaturedArtists(
+        9,
+        collection,
+        true,
+        artworks.merchandisable_artists,
+        mockMediator,
+        {}
+      )
 
-    const artist = entities.at(0).props().FollowButton.props.artist
-    expect(artist).toMatchObject({
-      id: "kaws",
-      _id: "4e934002e340fa0001005336",
-      name: "KAWS",
-      imageUrl:
-        "https://d32dm0rphc51dk.cloudfront.net/WhacjFyMKlMkNVzncPjlRA/square.jpg",
-      birthday: "1974",
-      nationality: "American",
+      expect(results.length).toEqual(1)
+    })
+
+    it("passes correct arguments featuredArtistsEntityCollection", () => {
+      const { collection, artworks } = props
+
+      const wrapper = shallow(
+        <div>
+          {getFeaturedArtists(
+            9,
+            collection,
+            true,
+            artworks.merchandisable_artists,
+            mockMediator,
+            {}
+          )}
+        </div>
+      )
+
+      const entities = wrapper.find(EntityHeader)
+      expect(entities.length).toBe(1)
+
+      const artist = entities.at(0).props().FollowButton.props.artist
+      expect(artist).toMatchObject({
+        id: "kaws",
+        _id: "4e934002e340fa0001005336",
+        name: "KAWS",
+        imageUrl:
+          "https://d32dm0rphc51dk.cloudfront.net/WhacjFyMKlMkNVzncPjlRA/square.jpg",
+        birthday: "1974",
+        nationality: "American",
+      })
     })
   })
+
+  describe("collection meta data", () => {
+    function mountComponent(theProps: Props, breakpoint: "sm" | "lg" = "sm") {
+      return mount(
+        <MockBoot breakpoint={breakpoint}>
+          <CollectionHeader {...theProps} />
+        </MockBoot>
+      )
+    }
+
+    it("renders the title", () => {
+      props.collection.title = "Scooby Doo"
+
+      const component = mountComponent(props)
+
+      expect(component.text()).toContain("Scooby Doo")
+    })
+
+    it("renders breadcrumb category", () => {
+      props.collection.category = "Nachos"
+
+      const component = mountComponent(props)
+
+      expect(component.text()).toContain("All works")
+      expect(component.text()).toContain("Nachos")
+    })
+
+    describe("description", () => {
+      describe("smaller screen", () => {
+        it("renders truncated description if description exists", () => {
+          props.collection.description = "some description"
+
+          const component = mountComponent(props)
+
+          const readMore = component.find("ReadMore")
+          expect(readMore.length).toEqual(1)
+          expect(readMore.text()).toContain("some description")
+        })
+
+        it("renders truncation with no text if description does not exist", () => {
+          props.collection.description = undefined
+
+          const component = mountComponent(props)
+
+          const readMore = component.find("ReadMore")
+          expect(readMore.length).toEqual(1)
+          expect(readMore.text()).toEqual("")
+        })
+      })
+
+      describe("larger screen", () => {
+        it("renders description untruncated if description exists", () => {
+          props.collection.description = "some description"
+
+          const component = mountComponent(props, "lg")
+
+          expect(component.find("ReadMore").length).toEqual(0)
+          expect(component.text()).toContain("some description")
+        })
+      })
+
+      it("renders a formatted string description", () => {
+        props.collection.description = "<i>your description</i>"
+
+        const component = mountComponent(props)
+
+        expect(component.html()).toContain("<i>your description</i>")
+      })
+
+      it("renders a JSX description", () => {
+        // though we don't really know how those happen.
+
+        // TODO - this test is currently failing. We'll need to make it pass
+        //  if we want to continue to accept JSX for the description field
+        //  Note: it was broken before refactoring, so it may be a known bug.
+        props.collection.description = <div>something</div>
+
+        const component = mountComponent(props)
+
+        expect(component.text()).toContain("some description")
+      })
+    })
+  })
+
+  // describe("collection header featured artists rail", () => {
+  //   it("renders featured artists when featured artists exist", () => {})
+  //   it("does not render featured artists when they don't exist", () => {})
+  // })
 })

--- a/src/Apps/Collect/Components/Collection/Header/__tests__/Header.test.tsx
+++ b/src/Apps/Collect/Components/Collection/Header/__tests__/Header.test.tsx
@@ -68,6 +68,14 @@ describe("collections header", () => {
     }
   })
 
+  function mountComponent(theProps: Props, breakpoint: "sm" | "lg" = "sm") {
+    return mount(
+      <MockBoot breakpoint={breakpoint}>
+        <CollectionHeader {...theProps} />
+      </MockBoot>
+    )
+  }
+
   describe("getFeaturedArtists", () => {
     const mockMediator = jest.fn()
 
@@ -118,14 +126,6 @@ describe("collections header", () => {
   })
 
   describe("collection meta data", () => {
-    function mountComponent(theProps: Props, breakpoint: "sm" | "lg" = "sm") {
-      return mount(
-        <MockBoot breakpoint={breakpoint}>
-          <CollectionHeader {...theProps} />
-        </MockBoot>
-      )
-    }
-
     it("renders the title", () => {
       props.collection.title = "Scooby Doo"
 
@@ -184,24 +184,33 @@ describe("collections header", () => {
 
         expect(component.html()).toContain("<i>your description</i>")
       })
-
-      it("renders a JSX description", () => {
-        // though we don't really know how those happen.
-
-        // TODO - this test is currently failing. We'll need to make it pass
-        //  if we want to continue to accept JSX for the description field
-        //  Note: it was broken before refactoring, so it may be a known bug.
-        props.collection.description = <div>something</div>
-
-        const component = mountComponent(props)
-
-        expect(component.text()).toContain("some description")
-      })
     })
   })
 
-  // describe("collection header featured artists rail", () => {
-  //   it("renders featured artists when featured artists exist", () => {})
-  //   it("does not render featured artists when they don't exist", () => {})
-  // })
+  describe("collection header featured artists rail", () => {
+    it("renders featured artists when featured artists exist", () => {
+      props.collection.query = {
+        gene_id: null,
+        artist_id: null,
+        artist_ids: [],
+      }
+      const component = mountComponent(props, "lg")
+      const entityHeaders = component.find(EntityHeader)
+
+      expect(component.text()).toContain("Featured Artists")
+      expect(entityHeaders.length).toEqual(4)
+    })
+
+    it("does not render featured artists when they don't exist", () => {
+      props.artworks = {
+        " $refType": null,
+        merchandisable_artists: [],
+      }
+      const component = mountComponent(props, "lg")
+      const entities = component.find(EntityHeader)
+
+      expect(component.text()).not.toContain("Featured Artists")
+      expect(entities.length).toEqual(0)
+    })
+  })
 })

--- a/src/Apps/Collect/Components/Collection/Header/index.tsx
+++ b/src/Apps/Collect/Components/Collection/Header/index.tsx
@@ -33,7 +33,7 @@ export interface Props {
     artist_ids?: string[]
     category: string
     credit?: string
-    description?: JSX.Element | string
+    description?: string
     gene_ids?: string[]
     headerImage: string
     major_periods?: string[]

--- a/src/Apps/Collect/Components/Collection/Header/index.tsx
+++ b/src/Apps/Collect/Components/Collection/Header/index.tsx
@@ -27,7 +27,8 @@ import { useSystemContext } from "Artsy"
 import { FollowArtistButtonFragmentContainer as FollowArtistButton } from "Components/FollowButton/FollowArtistButton"
 import { AuthModalIntent, openAuthModal } from "Utils/openAuthModal"
 
-interface Props {
+// TODO: Update query interface when we know the schema
+export interface Props {
   collection: {
     artist_ids?: string[]
     category: string
@@ -42,16 +43,6 @@ interface Props {
     query: any
   }
   artworks: Header_artworks
-}
-
-const getReadMoreContent = description => {
-  return (
-    <>
-      {description && (
-        <span dangerouslySetInnerHTML={{ __html: description }} />
-      )}
-    </>
-  )
 }
 
 const handleOpenAuth = (mediator, artist) => {
@@ -187,6 +178,7 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
     artworks.merchandisable_artists &&
     artworks.merchandisable_artists.length > 1
 
+  // TODO: Add test here to test this method works as expected
   const truncateFeaturedArtists = (featuredArtists, isColumnLayout) => {
     const width = getWidth()
     const truncatedLength = sd.IS_MOBILE
@@ -219,10 +211,19 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
       </EntityContainer>
     )
     const artists = cloneDeep(featuredArtists)
+    // TODO: Add test for splice method
     artists.splice(truncatedLength, remainingArtists, viewMore)
 
+    // TODO: Add test for each case that can be returned
     return showMore ? featuredArtists : artists
   }
+
+  // TODO: casting description as any allows this to pass type-checking, but
+  //  the test that uses a JSX description will fail anyway, so we should
+  //  fix this to account for that.
+  const htmlUnsafeDescription = collection.description && (
+    <span dangerouslySetInnerHTML={{ __html: collection.description as any }} />
+  )
 
   return (
     <Responsive>
@@ -284,12 +285,10 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
                           {smallerScreen ? (
                             <ReadMore
                               maxChars={chars}
-                              content={getReadMoreContent(
-                                collection.description
-                              )}
+                              content={htmlUnsafeDescription}
                             />
                           ) : (
-                            getReadMoreContent(collection.description)
+                            htmlUnsafeDescription
                           )}
                           {collection.description && <Spacer mt={2} />}
                         </ExtendedSerif>
@@ -297,6 +296,7 @@ export const CollectionHeader: FC<Props> = ({ artworks, collection }) => {
                     </Col>
                     <Col sm={12} md={12}>
                       {featuredArtists.length > 0 && (
+                        // TODO: Add test here to test when featuredArtists are present and not
                         <Box pb={10}>
                           <Sans size="2" weight="medium" pb={15}>
                             {`Featured Artist${hasMultipleArtists ? "s" : ""}`}


### PR DESCRIPTION
This is continued work on the c[ollections header tests](https://artsyproduct.atlassian.net/browse/GROW-1282). 

The PR addresses the following: 

- Types the collection description as a string.
- Removes the description spec testing for JSX.
- Adds two more tests for Featured Artists.

I realized I rebased master before starting this work so the two branches are out of sync so maybe there is a better approach to coordinating. I figured I'd submit a PR anyway so that you can see my changes.